### PR TITLE
Fix various problems with license-report

### DIFF
--- a/lib/extractLink.js
+++ b/lib/extractLink.js
@@ -11,6 +11,7 @@ module.exports = function(json) {
 	var otherUrls = []
 
 	visit(json, function(value) {
+		value = String(value)
 		if (value.substr(0, 'http'.length) === 'http')
 			return otherUrls.push(value)
 

--- a/lib/getPackageJson.js
+++ b/lib/getPackageJson.js
@@ -13,7 +13,7 @@ var get = module.exports = function(name, versionOrCallback, callback) {
 
 	debug('REQUEST %s', uri)
 
-	request(uri, function(err, response, body) {
+	request({uri: uri, gzip: true}, function(err, response, body) {
 		if (err) {
 			return callback(err)
 		}


### PR DESCRIPTION
1. For some packages `value` is not a string, but `substr` is always called
2. The `npm` registry has gone crazy and is returning gzipped content randomly, so force gzip so the client expects it