### PR TITLE
Hard-code @types license info.

### DIFF
--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -14,8 +14,34 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 	var versionRange = versionRangeOrCallback
 
 	if (arguments.length === 2) {
+			/*
+				Hard-coded license info for TS definitions, which look like
+				"@types/angular": "1.5.16"
+				These point to Definitely Typed, which is MIT Licensed
+			*/
+
+			if (/^@types\/.+/.test(package)) {
+
+			var split = package.split('@')
+
+			if (split.length !== 3)
+				throw new Error('invalid package: ' + package)
+
+			callback = versionRangeOrCallback
+			package = '@' + split[1]
+			versionRange = split[2]
+
+			callback(null, {
+				name: package,
+				licenseType: 'MIT',
+				link: 'https://github.com/DefinitelyTyped/DefinitelyTyped',
+				comment: versionRange
+			})
+			return;
+
+    }
 		var split = package.split('@')
-		
+
 		if (split.length !== 2)
 			throw new Error('invalid package: ' + package)
 
@@ -26,12 +52,12 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 
 	if (typeof callback !== 'function')
 		throw new Error('missing callback argument')
-	
+
 	versionRange = semver.validRange(versionRange)
 
 	if (!versionRange) {
 		var message = util.format('skipping %s (invalid semversion)', package)
-		
+
 		return callback(null, { name: package, comment: message })
 	}
 
@@ -39,7 +65,7 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 		if (err) return callback(err)
 
 		// dont think is is possible but just to make sure.
-		if (!json.versions) 
+		if (!json.versions)
 			return callback(new Error('no versions in registry for package ' + package))
 
 		// find the right version for this package
@@ -47,7 +73,7 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 
 		var version = semver.maxSatisfying(versions, versionRange)
 
-		if (!version) 
+		if (!version)
 			return callback(new Error('cannot find a version that satisfies range ' + versionRange + ' in the registry'))
 
 		getPackageJson(package, version, function(err, json) {
@@ -56,7 +82,7 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 			/*
 				finally, callback with all the data
 			*/
-			callback(null, { 
+			callback(null, {
 				name: package,
 				licenseType: extractLicense(json),
 				link: extractLink(json),

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -33,7 +33,7 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 
 			callback(null, {
 				name: package,
-				licenseType: 'MIT',
+				licenseType: 'DefinitelyTyped',
 				link: 'https://github.com/DefinitelyTyped/DefinitelyTyped',
 				comment: versionRange
 			})


### PR DESCRIPTION
Not code that I'm super proud of but this takes care of the `@types/...` issue.
Results in stuff like
```
{
  "department": "kessler",
  "relatedTo": "stuff",
  "name": "@types/angular",
  "licensePeriod": "perpetual",
  "material": "material",
  "licenseType": "DefintelyTyped",
  "link": "https://github.com/DefinitelyTyped/DefinitelyTyped",
  "comment": "1.5.16"
}, {
  "department": "kessler",
  "relatedTo": "stuff",
  "name": "@types/angular-mocks",
  "licensePeriod": "perpetual",
  "material": "material",
  "licenseType": "DefinitelyTyped",
  "link": "https://github.com/DefinitelyTyped/DefinitelyTyped",
  "comment": "1.5.5"
}
```
@gdgib-bina has volunteered to handle the downstream tool that will make some sense of the "DefinitelyTyped" license.