### PR TITLE
Adding special handling for @angular modules

### DIFF
--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -8,8 +8,8 @@ var extractLicense = require('./extractLicense.js')
 module.exports = getPackageReportData
 
 var knownLicenses = {
-	"^@types\/.+": 	{ licenseType: 'DefinitelyTyped',	link: 'https://github.com/DefinitelyTyped/DefinitelyTyped'},
-	"^@angular\/.+":{ licenseType: 'MIT',				link: 'https://github.com/angular/angular'}
+	"^@types\/.+": 	{ licenseType: 'DefinitelyTyped', link: 'https://github.com/DefinitelyTyped/DefinitelyTyped'},
+	"^@angular\/.+":{ licenseType: 'AngularModules', link: 'https://github.com/angular/angular'}
 }
 
 function getKnownLicenseInfoFor(package){

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -9,7 +9,7 @@ module.exports = getPackageReportData
 
 var knownLicenses = {
 	"^@types\/.+": 	{ licenseType: 'DefinitelyTyped',	link: 'https://github.com/DefinitelyTyped/DefinitelyTyped'},
-	"^@angular\/.+":{ licenseType: 'MIT', 				link: 'https://github.com/angular/angular'}
+	"^@angular\/.+":{ licenseType: 'MIT',				link: 'https://github.com/angular/angular'}
 }
 
 function getKnownLicenseInfoFor(package){
@@ -50,7 +50,7 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 			return;
 
 		}
-		var split = package.split('@')
+		var split = package.split('@', 2)
 
 		if (split.length !== 2)
 			throw new Error('invalid package: ' + package)

--- a/lib/getPackageReportData.js
+++ b/lib/getPackageReportData.js
@@ -7,6 +7,17 @@ var extractLicense = require('./extractLicense.js')
 
 module.exports = getPackageReportData
 
+var knownLicenses = {
+	"^@types\/.+": 	{ licenseType: 'DefinitelyTyped',	link: 'https://github.com/DefinitelyTyped/DefinitelyTyped'},
+	"^@angular\/.+":{ licenseType: 'MIT', 				link: 'https://github.com/angular/angular'}
+}
+
+function getKnownLicenseInfoFor(package){
+	for(var regex in knownLicenses)
+		if(new RegExp(regex).test(package))
+			return knownLicenses[regex];
+}
+
 /*
 	collect the data for a single package
 */
@@ -14,13 +25,12 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 	var versionRange = versionRangeOrCallback
 
 	if (arguments.length === 2) {
-			/*
-				Hard-coded license info for TS definitions, which look like
-				"@types/angular": "1.5.16"
-				These point to Definitely Typed, which is MIT Licensed
-			*/
-
-			if (/^@types\/.+/.test(package)) {
+		/*
+			Hard-coded license info for TS definitions and Agular modules,
+			which look like "@types/angular": "1.5.16"
+			These point to Definitely Typed or Angular, which are MIT Licensed
+		*/
+		if ((licInfo = getKnownLicenseInfoFor(package)) !== undefined)  {
 
 			var split = package.split('@')
 
@@ -33,13 +43,13 @@ function getPackageReportData(package, versionRangeOrCallback, callback) {
 
 			callback(null, {
 				name: package,
-				licenseType: 'DefinitelyTyped',
-				link: 'https://github.com/DefinitelyTyped/DefinitelyTyped',
+				licenseType: licInfo.licenseType,
+				link: licInfo.link,
 				comment: versionRange
 			})
 			return;
 
-    }
+		}
 		var split = package.split('@')
 
 		if (split.length !== 2)


### PR DESCRIPTION
Refactoring getPackageReportData.js to handle know licences for @angular/xxx modules with the same approach taken for @types/xxx.